### PR TITLE
Alerts for "add All" analysis

### DIFF
--- a/src/app/GraphFilter.ts
+++ b/src/app/GraphFilter.ts
@@ -9,6 +9,7 @@ export class GraphFilter {
     static Unmapped = 3;
     static ChildrenUnmapped = 4;
     static Filtered = 5;
+    static NoConnections = 6; // No connections visible, different than unmapped. 
 
     static visualTraits = [
       { color: 'unset', icon: '', alt: '' },
@@ -17,6 +18,7 @@ export class GraphFilter {
       { color: '#ff6969', icon: 'error', alt: 'This node is not mapped.' },
       { color: '#ffc0cb', icon: 'warning', alt: 'This node has children that are not mapped.' },
       { color: '#ffff00', icon: 'done', alt: 'This node is selected in the filter.' },
+      { color: '#f18f01', icon: 'error', alt: 'This node has no connections based on the active filter.' },
     ];
 
     public static runFilter(tab: GraphTab) {

--- a/src/app/graph/graph.component.html
+++ b/src/app/graph/graph.component.html
@@ -75,8 +75,8 @@
                              [class.node-content-wrapper-active]="node.isActive"
                              [class.node-content-wrapper-focused]="node.isFocused"
                              (click)="node.mouseAction('click', $event)"
-                             [style.background-color]="node|getNodeColor:t.column" id="{{t.id + '.lbl.' + node.data.node.id}}" >
-                          <div class="node-content-icon"><mat-icon class="node-content-icon" aria-hidden="false" title="{{node|getNodeIconAlt:t.column}}" attr.aria-label="{{node|getNodeIconAlt:t.column}}">{{node|getNodeIcon:t.column}}</mat-icon></div>
+                             [style.background-color]="t.displayLinks|getNodeColor:t:node" id="{{t.id + '.lbl.' + node.data.node.id}}" >
+                          <div class="node-content-icon"><mat-icon class="node-content-icon" aria-hidden="false" title="{{node|getNodeIconAlt:t}}" attr.aria-label="{{node|getNodeIconAlt:t}}">{{t.displayLinks|getNodeIcon:t:node}}</mat-icon></div>
                           <span [lang]="t.viewSettings.selectedLang">
                             <span *ngIf="!node.data.node.hyperlink" [innerHTML]="t.viewSettings|injectHighlightSection:node.data"></span>
                             <a *ngIf="node.data.node.hyperlink" (mousedown)="openTab(node.data.node.hyperlink)" class="fake-link" target="_blank" href="{{node.data.node.hyperlink}}" [innerHTML]="t.viewSettings|injectHighlightSection:node.data"></a>
@@ -139,9 +139,9 @@
                                [class.node-content-wrapper-active]="node.isActive"
                                [class.node-content-wrapper-focused]="node.isFocused"
                                (click)="node.mouseAction('click', $event)"
-                               [style.background-color]="node|getNodeColor:t.column"
+                               [style.background-color]="t.column.displayLinks|getNodeColor:t.column:node"
                                [attr.aria-expanded]="node.visibleChildren.length ? (node.isExpanded?'true':'false') : null">
-                            <div class="node-content-icon"><mat-icon aria-hidden="false" title="{{node|getNodeIconAlt:t.column}}" attr.aria-label="{{node|getNodeIconAlt:t.column}}">{{node|getNodeIcon:t.column}}</mat-icon></div>
+                            <div class="node-content-icon"><mat-icon aria-hidden="false" title="{{node|getNodeIconAlt:t.column}}" attr.aria-label="{{node|getNodeIconAlt:t.column}}">{{t.column.displayLinks|getNodeIcon:t.column:node}}</mat-icon></div>
                             <span [lang]="t.viewSettings.selectedLang">
                               <span *ngIf="!node.data.node.hyperlink">{{node|getSection:t.viewSettings}}</span>
                               <a *ngIf="node.data.node.hyperlink" (mousedown)="openTab(node.data.node.hyperlink)" class="fake-link" target="_blank" href="{{node.data.node.hyperlink}}">{{node|getSection:t.viewSettings}}</a>

--- a/src/app/pipes/NodePipe.ts
+++ b/src/app/pipes/NodePipe.ts
@@ -22,6 +22,14 @@ function getNodeStatus(tab: GraphTab, node: TreeNode)
     // if we're a tree in the right side view, highlight active nodes
     var status = GraphFilter.None;
 
+    if (tab.isAll && !tab.column) {
+      // We're on the right side all tab, We want dynamic connection coloring.
+      //  Show red if there are no visible connections. This is different than how we
+      //  normally show red if there are missing ISO connections.
+      var any = tab.displayLinks.filter(v => v.fromNode.id.startsWith(node.id)).length;
+      return any ? GraphFilter.None : GraphFilter.NoConnections;
+    }
+
     if (tab.parent && node.data.filterColor)
     {
         if (!tab.isIso && node.data.isUnmapped)
@@ -50,11 +58,7 @@ function getNodeStatus(tab: GraphTab, node: TreeNode)
 }
 
 function getNodeColor(tab: GraphTab, node: TreeNode)
-{
-    var coloringOnAllTab = true; // at one point it was desired to turn this off.    
-    if (!coloringOnAllTab && tab.isAll)
-      return "unset"; // skip coloring on ALL tab
-
+{   
     var color = GraphFilter.visualTraits[getNodeStatus(tab, node)].color;
                   
     // if we're a tree in the right side view
@@ -83,26 +87,40 @@ function getNodeIconAlt(tab: GraphTab, node: TreeNode)
     return alt;
 }
 
+/*
+ * These pipes are "pure". They're only calculated once and the value is cached.
+ * The value is recalculated when the first parameter changes.
+ * We use the 'displayLinks' as the cache key so that when the display links change
+ * (in response to a filter or expansion operation), then we recalculate these pipes.
+ *
+ * The displayLinks cache key is unused in the actual computation of the pipe.
+ */
 @Pipe({ name: 'getNodeColor' })
 export class getNodeColorPipe implements PipeTransform {
     constructor() {
     }
 
-    transform(node: TreeNode, tab: GraphTab): string {
+    transform(displayLinks: any, tab: GraphTab, node: TreeNode): string {
         return getNodeColor(tab, node);
     }
 }
 
+/*
+ * Same comment as above.
+ */
 @Pipe({ name: 'getNodeIcon' })
 export class getNodeIconPipe implements PipeTransform {
     constructor() {
     }
-
-    transform(node: TreeNode, tab: GraphTab): string {
+  
+    transform(displayLinks: any, tab: GraphTab, node: TreeNode): string {
         return getNodeIcon(tab, node);
     }
 }
 
+/*
+ * Same comment as above.
+ */
 @Pipe({ name: 'getNodeIconAlt' })
 export class getNodeIconAltPipe implements PipeTransform {
     constructor() {


### PR DESCRIPTION
**Issue:**
When users "add all" to the dpmap tool, only regulations that do not have matching(s) to the filtered items should have an alert. This is different from the regular "add one" alerts where we see red/pink alert whenever the regulation contains requirements not currently covered by the map.
The project has been having problem with the co-existence of the two different alerts. When we fix one the other would break. 

**Fix:**
Refactored how the colors and icons work on the "All" column. The "All" page should show icons and colors when there is no visible connections (dynamically based on the active filter). This is different than the other regulations that show an icon and color when there are missing mappings to ISO (static, computed at build time).

**Notes**
There is a slight delay between the filter change and the color updates while the connections are being recalculated. This is partly due to the debounce on the filter change and the asynchronous graph update. To fix this could require a redesign of the data model that presents the view result all at once rather than asynchronously. A different fix may be to simply delay the calculation of the colors until the view settles.